### PR TITLE
Use environment to control program arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npmlazy:
 ## Configuring the `npm_lazy` server
 
 The `npm_lazy/server` is wrapped with a thin client that allows you to
-dynamically configure the server from the command-line options on startup.
+dynamically configure the server from the command-line options or the environment on startup.
 
 You can configure the server by passing arguments when starting the container.
 
@@ -95,6 +95,17 @@ $ node index.js --help
     --host [value]
     --proxy_https [value]
     --proxy_http [value]
+```
+
+### Environment variables
+
+Any environment variables that start with `NPM_LAZY_` will be interpreted as a configuration argument. For example, putting `NPM_LAZY_PORT=80` in your environment will set the `--port` argument to `80`. Environment variables are case-sensitive, so `npm_lazy_port` will not work.
+
+```
+$ export NPM_LAZY_CACHE_DIRECTORY=/tmp/npm_lazy
+$ export NPM_LAZY_EXTERNAL_URL=http://npm_lazy
+$ export NPM_LAZY_PORT=80
+$ node index.js
 ```
 
 ## Configuring the `npm` client

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var s = require('underscore.string');
 
 var dasherize = s.dasherize.bind(s);
+var underscored = s.underscored.bind(s);
 
 module.exports.configureProgramOptions = function (config, program) {
   var createOption = _.partial(createOption, program);
@@ -27,7 +28,12 @@ module.exports.configureProgramOptions = function (config, program) {
     .flatten()
     .compact()
     .each(function (key) {
-      program.option('--'.concat(key).concat(' [value]'));
+      var envKey = 'NPM_LAZY_' + underscored(key).toUpperCase(), envDefault = undefined;
+
+      if (envKey in process.env) {
+          envDefault = process.env[envKey];
+      }
+      program.option('--'.concat(key).concat(' [value]'), undefined, envDefault);
     });
 }
 


### PR DESCRIPTION
See #16:

> I pushed a [commit](https://github.com/StanAngeloff/npm_lazy/commit/174bf2a429e900fd3b875155d7c825a2fd0b72fb) earlier today that allows the use of environment variables.
> 
> I thought you may be interested in cherry-picking if you found it useful?
> 
> ``` sh
> export NPM_LAZY_PORT=80
> export NPM_LAZY_EXTERNAL_URL=http://localhost
> node index.js
> ```
